### PR TITLE
added publishing script and updated versions

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -27,17 +27,11 @@ jobs:
           node-version: 22.1.0
           registry-url: 'https://registry.npmjs.org/'
 
-      - name: Add npmrc file
-        run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
-
       - name: Install dependencies
         run: yarn install
 
-      - name: Build all packages
-        run: yarn build
-
       - name: Publish all packages
-        run: yarn workspaces foreach --all --no-private npm publish --access public
+        run: yarn publish:ci
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,8 @@
     "test": "vitest run",
     "lint": "eslint",
     "lint:fix": "yarn lint --fix",
-    "generate-docs": "ts-node scripts/generateReadme.ts"
+    "generate-docs": "ts-node scripts/generateReadme.ts",
+    "publish:ci": "ts-node scripts/publish.ts"
   },
   "devDependencies": {
     "@types/fs-extra": "^11",

--- a/packages/caret/package.json
+++ b/packages/caret/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@editorjs/caret",
   "description": "Utils useful for work with caret for Editor.js tools development",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
@@ -9,5 +9,8 @@
   },
   "dependencies": {
     "@editorjs/dom": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/dom/package.json
+++ b/packages/dom/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@editorjs/dom",
   "description": "Utils useful for work with dom for Editor.js tools development",
-  "version": "0.0.4",
+  "version": "0.0.6",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
@@ -9,5 +9,8 @@
   },
   "dependencies": {
     "@editorjs/helpers": "workspace:^"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/helpers/package.json
+++ b/packages/helpers/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@editorjs/helpers",
   "description": "Utils useful for Editor.js tools development",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "build": "tsc --project tsconfig.build.json"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/packages/keyboard/package.json
+++ b/packages/keyboard/package.json
@@ -1,10 +1,13 @@
 {
   "name": "@editorjs/keyboard",
   "description": "Utils useful for work with keyboard for Editor.js tools development",
-  "version": "0.0.4",
+  "version": "0.0.5",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {
     "build": "tsc"
+  },
+  "publishConfig": {
+    "access": "public"
   }
 }

--- a/scripts/publish.ts
+++ b/scripts/publish.ts
@@ -1,0 +1,39 @@
+import { execSync } from 'child_process';
+import * as path from 'path';
+import { pathExistsSync, statSync, readdirSync } from 'fs-extra';
+
+const packagesDir = path.join(__dirname, '..', 'packages');
+
+/**
+ * Function that returns names of all packages in /packages directory
+ */
+function getPackages(): string[] {
+  const directories = readdirSync(packagesDir).filter((dir) => {
+    /**
+     * Actutal path to the package in project
+     */
+    const pathToPackage = path.join('packages', dir);
+
+    /**
+     * Check if path is a directory (not a file)
+     * Check if path contains package.json (directory is actually package and could be published)
+     */
+    return statSync(pathToPackage).isDirectory() && pathExistsSync(path.join(pathToPackage, 'package.json'));
+  });
+
+  return directories;
+}
+
+execSync('npm run build', { stdio: 'inherit' });
+
+let command = 'yarn npm publish --access public';
+
+const packages = getPackages();
+
+/**
+ * For each package run yarn npm publish
+ */
+for (const name of packages) {
+  execSync(command, { stdio: 'inherit',
+    cwd: path.join('packages', name) });
+}


### PR DESCRIPTION
now publishing will be done with `yarn npm publish` so that Yarn substitutes versions of dependencies written as 'workspace/*'
![image](https://github.com/user-attachments/assets/ecc32121-6de8-4c3e-9130-d7471a52b564)
tested with `@editorjs/dom` published without workflow
- Fix publish package workflow
- Added publish:ci script that will be used in publish packge workflow