### PR TITLE
fix(caret): fix focus at start when first child is empty

### DIFF
--- a/packages/caret/package.json
+++ b/packages/caret/package.json
@@ -3,7 +3,7 @@
   "description": "Utils useful for work with caret for Editor.js tools development",
   "repository": "https://github.com/editor-js/utils/tree/main/packages/caret",
   "link": "https://github.com/editor-js/utils/tree/main/packages/caret",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "main": "dist/index.js",
   "license": "MIT",
   "scripts": {

--- a/packages/caret/src/focus/focus.ts
+++ b/packages/caret/src/focus/focus.ts
@@ -23,11 +23,16 @@ export function focus(element: HTMLElement, atStart: boolean = true): void {
     /**
      * Helper function to create a new text node and set the caret
      * @param parent - parent element to append the text node
+     * @param prepend
      */
-    const createAndFocusTextNode = (parent: HTMLElement): void => {
+    const createAndFocusTextNode = (parent: HTMLElement | ChildNode, prepend = false): void => {
       const textNode = document.createTextNode('');
 
-      parent.appendChild(textNode);
+      if (prepend) {
+        parent.insertBefore(textNode, parent.firstChild);
+      } else {
+        parent.appendChild(textNode);
+      }
       range.setStart(textNode, 0);
       range.setEnd(textNode, 0);
     };
@@ -67,7 +72,7 @@ export function focus(element: HTMLElement, atStart: boolean = true): void {
         /**
          * If no text node is found, create one and set focus
          */
-        createAndFocusTextNode(element);
+        createAndFocusTextNode(element, atStart);
       }
     } else {
       /**

--- a/packages/caret/src/focus/focus.ts
+++ b/packages/caret/src/focus/focus.ts
@@ -23,7 +23,7 @@ export function focus(element: HTMLElement, atStart: boolean = true): void {
     /**
      * Helper function to create a new text node and set the caret
      * @param parent - parent element to append the text node
-     * @param prepend
+     * @param prepend - should the text node be prepended or appended
      */
     const createAndFocusTextNode = (parent: HTMLElement | ChildNode, prepend = false): void => {
       const textNode = document.createTextNode('');


### PR DESCRIPTION
Now if first child is empty, focus will always set caret at the end. 

This change handles the "atStart" correctly for this case